### PR TITLE
status() now erases trailing digit when changing 'Tick size'

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -1,0 +1,164 @@
+/*
+ * INVOKING INDENT
+ */
+// --standard-output // Write to standard output.
+// --ignore-profile // Do not read ‘.indent.pro’ files. Hmmm, kinda too late, isn't it?
+
+
+/*
+ * COMMON STYLES
+ */
+// --gnu-style // Use GNU coding style.  This is the default.
+--k-and-r-style // Use Kernighan & Ritchie coding style.
+// --original // Use the original Berkeley coding style.
+// --linux-style // Use Linux coding style.
+
+
+/*
+ * BLANK LINES
+ */
+// --blank-lines-after-declarations // Force blank lines after the declarations.
+// --no-blank-lines-after-declarations // Do not force blank lines after declarations.
+
+// --blank-lines-after-procedures // Force blank lines after procedure bodies.
+// --no-blank-lines-after-procedures // Do not force blank lines after procedure bodies.
+
+// --blank-lines-before-block-comments // Force blank lines before block comments.
+
+// --swallow-optional-blank-lines // Swallow optional blank lines.
+// --leave-optional-blank-lines // Do not swallow optional blank lines.
+
+
+/*
+ * COMMENTS
+ */
+// --format-all-comments // Do not disable all formatting of comments.
+// --dont-format-comments // Do not format any comments.
+
+// --comment-indentationn // Put comments to the right of code in column n.
+// --line-comments-indentationn // Set indentation of comments not to the right of code to n spaces.
+// --declaration-comment-columnn // Put comments to the right of the declarations in column n.
+
+// --comment-delimiters-on-blank-lines // Put comment delimiters on blank lines.
+// --no-comment-delimiters-on-blank-lines // Do not put comment delimiters on blank lines.
+
+// --format-first-column-comments // Format comments in the first column.
+// --dont-format-first-column-comments // Do not format comments in the first column as normal.
+
+// --comment-line-lengthn // Set maximum line length for comment formatting to n.
+// --dont-star-comments // Do not put the ‘*’ character at the left of comments.
+// --start-left-side-of-comments // Put the ‘*’ character at the left of comments.
+
+
+/*
+ * STATEMENTS
+ */
+// --space-after-if // Put a space after each if.
+--no-space-after-if // Do not put a space after every if.
+// --braces-on-if-line // Put braces on line with if, etc.
+--braces-after-if-line // Put braces on line after if, etc.
+// --cuddle-else // Cuddle else and preceding ‘}’.
+// --dont-cuddle-else // Do not cuddle } and else.
+
+// --space-after-for // Put a space after each for.
+--no-space-after-for // Do not put a space after every for.
+
+// --space-after-while // Put a space after each while.
+--no-space-after-while // Do not put a space after every while.
+// --cuddle-do-while // Cuddle while of do {} while; and preceding ‘}’.
+--dont-cuddle-do-while // Do not cuddle } and the while of a do {} while;.
+
+// --case-brace-indentationn // Indent braces after a case label N spaces.
+--case-indentation4 // Case label indent of n spaces.
+
+// --struct-brace-indentationn // Indent braces of a struct, union or enum N spaces.
+
+--brace-indent0 // Indent braces n spaces.
+--continuation-indentation4 // Continuation indent of n spaces.
+
+// --space-after-procedure-calls // Insert a space between the name of the procedure being called and the ‘(’.
+// --no-space-after-function-call-names // Do not put space after the function in function calls.
+
+// --space-after-parentheses // Put a space after every ’(’ and before every ’)’.
+// --no-space-after-parentheses // Do not put a space after every ’(’ and before every ’)’.
+// --paren-indentationn // Specify the extra indentation per open parentheses ’(’ when a statement is bro‐
+// --dont-line-up-parentheses // Do not line up parentheses.
+
+// --space-after-cast // Put a space after a cast operator.
+// --no-space-after-casts // Do not put a space after cast operators.
+
+// --space-special-semicolon // On one-line for and while statements, force a blank before the semicolon.
+// --dont-space-special-semicolon // Do not force a space before the semicolon after certain statements. Disables ‘-ss’.
+
+// --blank-before-sizeof // Put a space between sizeof and its argument.
+
+
+/*
+ * DECLARATIONS
+ */
+// --declaration-indentationn // Put variables in column n.
+// --blank-lines-after-commas // Force newline after comma in declaration.
+// --no-blank-lines-after-commas // Do not force newlines after commas in declarations.
+
+// --break-function-decl-args // Break the line before all arguments in a declaration.
+// --dont-break-function-decl-args // Don’t put each argument in a function declaration on a separate line.
+// --break-function-decl-args-end // Break the line after the last argument in a declaration.
+
+// --procnames-start-lines // Put the type of a procedure on the line before its name.
+// --dont-break-procedure-type // Put the type of a procedure on the same line as its name.
+
+// -T // Tell indent the name of typenames.
+
+// --braces-on-func-def-line // Put braces on function definition line.
+// --braces-after-func-def-line // Put braces on line following function definition line.
+
+// --braces-on-struct-decl-line // Put braces on struct declaration line.
+// --braces-after-struct-decl-line // Put braces on the line after struct declaration lines.
+
+// --left-justify-declarations // If -cd 0 is used then comments after declarations are left justified  behind  the declaration.
+// --dont-left-justify-declarations // Comments  after  declarations are treated the same as comments after other statments.
+
+
+/*
+ * INDENTATION
+ */
+--indent-level4 // Set indentation level to n spaces.
+
+// --use-tabs // Use tabs. This is the default.
+--no-tabs // Use spaces instead of tabs.
+// --tab-sizen // Set tab size to n spaces.
+
+// --parameter-indentationn // Indent parameter types in old-style function definitions by n spaces.
+// --no-parameter-indentation // Zero width indentation for parameters.
+
+--continue-at-parentheses // Line up continued lines at parentheses.
+
+// --leave-preprocessor-space // Leave space between ‘#’ and preprocessor directive.
+// --preprocessor-indentationn // Specify the indentation for preprocessor conditional statements.
+
+// --indent-labeln // Set offset for labels to column n.
+
+
+/*
+ * BREAKING LONG LINES
+ */
+--line-length72 // Set maximum line length for non-comment lines to n.
+
+// --break-before-boolean-operator // Prefer to break long lines before boolean operators.
+// --break-after-boolean-operator // Do not prefer to break long lines before boolean operators.
+
+// --honour-newlines // Prefer to break long lines at the position of newlines in the input.
+// --ignore-newlines // Do not prefer to break long lines at the position of newlines in the input.
+
+
+/*
+ * MISCELLANEOUS OPTIONS
+ */
+// --verbose // Enable verbose mode.
+// --no-verbosity // Disable verbose mode.
+
+// --preserve-mtime // Preserve  access  and  modification  times   on   output   files.
+
+// --else-endif-columnn // Put comments to the right of #else and #endif statements in column n.
+
+// -version // Output the version number of indent.

--- a/life.c
+++ b/life.c
@@ -51,10 +51,6 @@ static WINDOW *life = NULL;
 /* Holds the sleep time */
 static struct timespec sleeptime = {0};
 
-/* Prints the game area, but is not used since the curses interface. Obsolete
- * */
-void print();
-
 /* Prints status information about the game. Window size, game size, tick size
  * etc. Populates the info-window */
 void status();
@@ -329,25 +325,6 @@ void init()
 
     /* Write the first status information */
     status();
-}
-
-void print()
-{
-    int x, y;
-    printf("\n");
-    for(x = 0; x < COLS+2; x++)
-        printf("-");
-    printf("\n");
-    for(y = 0; y < LINES; y++)
-    {
-        printf("|");
-        for(x = 0; x < COLS; x++)
-            printf("%d", CELL(y, x));
-        printf("|\n");
-    }
-    for(x = 0; x < COLS+2; x++)
-        printf("-");
-    printf("\n");
 }
 
 void status()

--- a/life.c
+++ b/life.c
@@ -111,16 +111,16 @@ bool kbd(int ch)
             return false;
             break;
         case KEY_RIGHT: /* Go right */
-            x=(x+1)%CMAX;
+            x=(x+1)%lifecols;
             break;
         case KEY_LEFT: /* Go left */
-            x=(x+CMAX-1)%CMAX;
+            x=(x+lifecols-1)%lifecols;
             break;
         case KEY_DOWN: /* Go down */
-            y=(y+1)%LMAX;
+            y=(y+1)%lifelines;
             break;
         case KEY_UP: /* Go up */
-            y=(y+LMAX-1)%LMAX;
+            y=(y+lifelines-1)%lifelines;
             break;
         case ' ': /* Activate a cell */
             activate(y, x);
@@ -306,9 +306,8 @@ void initcurses()
      * before writing. */
     mvwprintw(info, 1,1, "INFO");
 
-    /* Move the cursor back to game area. The user don't need to see the cursor
-     * jumping to the info-window */
-    wmove(life, 1,1);
+    /* Move the cursor to the centre of the field. */
+    wmove(life, lifelines/2, lifecols/2);
 
     /* Refresh both of the windows */
     wrefresh(info);
@@ -344,14 +343,14 @@ void status()
 {
     int y,x;
     getyx(life, y, x);
-    mvwprintw(info, 2, 1, "Total sizes");
+    mvwprintw(info, 2, 1, "Terminal size");
     mvwprintw(info, 3, 1, " Columns: %d", COLS);
     mvwprintw(info, 4, 1, " Lines: %d", LINES);
-    mvwprintw(info, 5, 1, "Life sizes");
+    mvwprintw(info, 5, 1, "Life field size");
     mvwprintw(info, 6, 1, " Columns: %d", lifecols);
     mvwprintw(info, 7, 1, " Lines: %d", lifelines);
     mvwprintw(info, 8, 1, "Array size: %d", ASIZE);
-    mvwprintw(info, 9, 1, "Tick size: %d ", ticksize);
+    mvwprintw(info, 9, 1, "Steps per run: %d ", ticksize);
 
     /* if we are currently running, say so in status bar */
     if(current_step > 0)

--- a/life.c
+++ b/life.c
@@ -41,6 +41,7 @@ static int lifelines = 0;
 
 /* Default tick size. How many iterations are made in a tick */
 static int ticksize = 1;
+static int minticksize = 1;
 
 /* Information window */
 static WINDOW *info = NULL;
@@ -130,7 +131,8 @@ bool kbd(int ch)
             status();
             break;
         case KEY_DOWN: /* Reduce tick size */
-            ticksize--;
+            if(ticksize > minticksize)
+              ticksize--;
             status();
             break;
     }

--- a/life.c
+++ b/life.c
@@ -43,6 +43,9 @@ static int lifelines = 0;
 static int ticksize = 1;
 static int minticksize = 1;
 
+/* The current iteration (tick) */
+static int current_step = 0;
+
 /* Information window */
 static WINDOW *info = NULL;
 /* Game area */
@@ -153,7 +156,7 @@ void tick()
      * y = y coordinate
      * n = neighbours for a coordinate
      */
-    int t, x, y, n;
+    int x, y, n;
     /* Sync the buffer with the game area
      * buffer <- cells.
      * The buffer and cells are separated so that the calculations from this
@@ -164,7 +167,7 @@ void tick()
      * during the round, but after we have finished the round, we can sync
      * them. */
     COPYC;
-    for(t = 0; t < ticksize; t++)
+    for(current_step = ticksize; current_step > 0; current_step--)
     { /* Iterations */
         for(x = 0; x < lifecols; x++)
         {
@@ -194,10 +197,17 @@ void tick()
         /* Sync the cells with the buffer */
         COPYB;
         /* Refresh the screen */
-        wrefresh(life);
+        //wrefresh(life);
+        status();
         /* Sleep for while */
         nanosleep(&sleeptime, remaining);
     }
+
+    /* remove the "Running" status when done */
+    current_step = 0;
+    mvwprintw(info, 11, 1, "       ");
+    mvwprintw(info, 12, 1, "            ");
+    wrefresh(info);
 }
 
 int neighbours(int y, int x)
@@ -344,6 +354,13 @@ void status()
     mvwprintw(info, 7, 1, " Lines: %d", lifelines);
     mvwprintw(info, 8, 1, "Array size: %d", ASIZE);
     mvwprintw(info, 9, 1, "Tick size: %d ", ticksize);
+
+    /* if we are currently running, say so in status bar */
+    if(current_step > 0)
+    {
+        mvwprintw(info, 11, 1, "Running");
+        mvwprintw(info, 12, 1, "  Step: %d ", current_step);
+    }
     getyx(life, y, x);
     wmove(life, y, x);
     wrefresh(info);

--- a/life.c
+++ b/life.c
@@ -133,18 +133,15 @@ bool kbd(int ch)
             break;
         case KEY_PPAGE: /* Increase tick size */
             ticksize++;
-            status();
             break;
         case KEY_NPAGE: /* Reduce tick size */
             if(ticksize > minticksize)
               ticksize--;
-            status();
             break;
     }
     wmove(life, y, x); /* Move the coordinates to the new location and refresh
                           the game area */
-    wrefresh(life);
-
+    status();
     return true;
 }
 
@@ -346,6 +343,7 @@ void init()
 void status()
 {
     int y,x;
+    getyx(life, y, x);
     mvwprintw(info, 2, 1, "Total sizes");
     mvwprintw(info, 3, 1, " Columns: %d", COLS);
     mvwprintw(info, 4, 1, " Lines: %d", LINES);
@@ -361,7 +359,8 @@ void status()
         mvwprintw(info, 11, 1, "Running");
         mvwprintw(info, 12, 1, "  Step: %d ", current_step);
     }
-    getyx(life, y, x);
+    /* print the cursor y and x position */
+    mvwprintw(info, ILINES-2, 1, "L = %d C = %d    ", y, x);
     wmove(life, y, x);
     wrefresh(info);
     wrefresh(life);

--- a/life.c
+++ b/life.c
@@ -104,20 +104,20 @@ bool kbd(int ch)
     int x,y; /* Holds the coordinates */
     getyx(life, y, x); /* Get the coordinates from curses life window */
     switch(ch)
-    { /* hjkl + q + space + enter */
+    {
         case 'q':
             return false;
             break;
-        case 'l': /* Go right */
+        case KEY_RIGHT: /* Go right */
             x=(x+1)%CMAX;
             break;
-        case 'h': /* Go left */
+        case KEY_LEFT: /* Go left */
             x=(x-1)%CMAX;
             break;
-        case 'j': /* Go down */
+        case KEY_DOWN: /* Go down */
             y=(y+1)%LMAX;
             break;
-        case 'k': /* Go up */
+        case KEY_UP: /* Go up */
             y=(y-1)%LMAX;
             break;
         case ' ': /* Activate a cell */
@@ -126,11 +126,11 @@ bool kbd(int ch)
         case 10: /* Enter. Start the tick */
             tick();
             break;
-        case KEY_UP: /* Increase tick size */
+        case KEY_PPAGE: /* Increase tick size */
             ticksize++;
             status();
             break;
-        case KEY_DOWN: /* Reduce tick size */
+        case KEY_NPAGE: /* Reduce tick size */
             if(ticksize > minticksize)
               ticksize--;
             status();

--- a/life.c
+++ b/life.c
@@ -358,7 +358,7 @@ void status()
     mvwprintw(info, 6, 1, " Columns: %d", lifecols);
     mvwprintw(info, 7, 1, " Lines: %d", lifelines);
     mvwprintw(info, 8, 1, "Array size: %d", ASIZE);
-    mvwprintw(info, 9, 1, "Tick size: %d", ticksize);
+    mvwprintw(info, 9, 1, "Tick size: %d ", ticksize);
     getyx(life, y, x);
     wmove(life, y, x);
     wrefresh(info);

--- a/life.c
+++ b/life.c
@@ -70,6 +70,9 @@ void tick();
 /* Activate a cell and the visual representation of it */
 void activate(int y, int x);
 
+/* Deactivate a cell erase its visual representation */
+void deactivate(int y, int x);
+
 /* A helper function for creating new windows */
 WINDOW *createwin(int height, int width, int begy, int begx);
 
@@ -118,6 +121,9 @@ bool kbd(int ch)
             break;
         case ' ': /* Activate a cell */
             activate(y, x);
+            break;
+        case KEY_DC: /* Deactivate a cell */
+            deactivate(y, x);
             break;
         case 10: /* Enter. Start the tick */
             tick();
@@ -350,4 +356,12 @@ void activate(int y, int x)
     CPR(y,x);
     /* And show it visually too */
     mvwaddch(life, y, x, 'X');
+}
+
+void deactivate(int y, int x)
+{
+    /* Set the cell dead in the array */
+    ACPR(y,x);
+    /* And erase its visual representation */
+    mvwaddch(life, y, x, ' ');
 }

--- a/life.c
+++ b/life.c
@@ -114,13 +114,13 @@ bool kbd(int ch)
             x=(x+1)%CMAX;
             break;
         case KEY_LEFT: /* Go left */
-            x=(x-1)%CMAX;
+            x=(x+CMAX-1)%CMAX;
             break;
         case KEY_DOWN: /* Go down */
             y=(y+1)%LMAX;
             break;
         case KEY_UP: /* Go up */
-            y=(y-1)%LMAX;
+            y=(y+LMAX-1)%LMAX;
             break;
         case ' ': /* Activate a cell */
             activate(y, x);

--- a/macros.h
+++ b/macros.h
@@ -39,11 +39,10 @@ THE SOFTWARE.
 # define ASIZE (lifecols*lifelines) /* Amount of cells */
 # define SIZE (ASIZE*sizeof(int)) /* And the real size of it */
 
-# define CPR(y, x) (cells[COORD((y),(x))] = 1) /* Give CPR to the defined
-                                                  coordinate. (Make it alive)
-                                                  */
+# define CPR(y, x) (cells[COORD((y),(x))] = 1) /* Give cell life */
 # define BCPR(y, x) (buffer[COORD((y),(x))] = 1) /* The same but for buffer */
-# define ABCPR(y, x) (buffer[COORD((y),(x))] = 0) /* Kill the cell. Anticpr */
+# define ACPR(y, x) (cells[COORD((y),(x))] = 0) /* Kill the cell. AntiCPR */
+# define ABCPR(y, x) (buffer[COORD((y),(x))] = 0) /* The same but for buffer */
 
 # define COPYB memcpy(cells, buffer, SIZE) /* Sync the cells with the data from
                                               the buffer */


### PR DESCRIPTION
There was a bug:

When you increase the tick size then decrease it again, the trailing '0' would remain on the screen when decreasing from 10 to 9.

I added a space at the end of the string "Tick size: %d". Now the trailing '0' is erased when decrementing.